### PR TITLE
Update post.html

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -14,7 +14,7 @@ layout: description
     {% assign categories = page.categories %}
   {% endif %}
   {% for category in categories %}
-      <a href="{{site.url}}/categories/#{{category|slugize}}">{{category}}</a>
+      <a href="{{site.baseurl}}/categories/#{{category|slugize}}">{{category}}</a>
   {% unless forloop.last %}&nbsp;{% endunless %}
   {% endfor %}
 </div>


### PR DESCRIPTION
When you click category at the bottom of post.html, it is entered as a relative path and moves to the wrong link.
ex) https://XXX.github.io/finance/option/2019/01/14/XXX.github.io/categories/#Finance

So you need to change it to an absolute path. 😄
