### PR TITLE
Fix : Use page.post to display post date

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,7 +2,7 @@
 layout: description
 ---
 <h2>{{ page.title }}</h2>
-<small>{{ post.date | date_to_string }}</small>
+<small>{{ page.date | date_to_string }}</small>
 {{content}}
 
 <div class="post-footer">


### PR DESCRIPTION
In the post.html, use  `page.date`, otherwise it won't show the date. This closes #51.